### PR TITLE
add insecure support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ target
 .classpath
 .settings
 .project
+*.json
+.clj-kondo

--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ In order to trigger the use of this repository wagon you need to replace the `ht
 
                "snapshots" {:url          "gitlab://gitlab.com/api/v4/projects/PROJECT_ID/packages/maven"
                             :username      "Private-Token"
-                            :password      :env/gitlab_private_token}}
+                            :password      :env/gitlab_private_token}
+               "insecure-release" {:url           "gitlab-insecure://gitlab.com/api/v4/projects/PROJECT_ID/packages/maven"
+                                    :username      "Job-Token"
+                                    :password      :env/ci_job_token
+                                    :sign-releases false}}
 ```
 
 #### Store credentials in an encrypted file

--- a/src/main/java/com/nicheware/maven/LeinGitlabWagon.java
+++ b/src/main/java/com/nicheware/maven/LeinGitlabWagon.java
@@ -33,11 +33,7 @@ package com.nicheware.maven;
  */
 
 import org.apache.maven.wagon.ConnectionException;
-import org.apache.maven.wagon.InputData;
-import org.apache.maven.wagon.ResourceDoesNotExistException;
-import org.apache.maven.wagon.TransferFailedException;
 import org.apache.maven.wagon.authentication.AuthenticationException;
-import org.apache.maven.wagon.authorization.AuthorizationException;
 import org.apache.maven.wagon.providers.http.HttpWagon;
 import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.apache.maven.wagon.proxy.ProxyInfoProvider;
@@ -46,9 +42,6 @@ import org.apache.maven.wagon.repository.Repository;
 import java.util.Properties;
 
 public class LeinGitlabWagon extends HttpWagon {
-
-    private static String GITLAB_SCHEME = "gitlab:";
-    private static String REPOSITORY_SCHEME = "https:";
 
     /**
      * If the repository URL scheme is "gitlab":
@@ -70,23 +63,17 @@ public class LeinGitlabWagon extends HttpWagon {
     public void connect(Repository repository, AuthenticationInfo authenticationInfo, ProxyInfoProvider proxyInfoProvider )
             throws ConnectionException, AuthenticationException {
 
-        if (repository.getUrl().startsWith(GITLAB_SCHEME)) {
-            repository.setUrl(correctUrl(repository));
+        String originalUrl = repository.getUrl();
+
+        if (originalUrl.startsWith("gitlab:") || originalUrl.startsWith("gitlab-insecure:") ) {
+            String replacedBy = originalUrl.startsWith("gitlab:") ? "https:" : "http:";
+            String newUrl = originalUrl.replaceFirst("gitlab.*?:", replacedBy);
+            repository.setUrl(newUrl);
             setHttpHeadersForAuthentication(authenticationInfo);
             super.connect(repository, null, proxyInfoProvider);
-        }
-        else {
+        }else{
             super.connect(repository, authenticationInfo, proxyInfoProvider);
         }
-    }
-
-    /**
-     * Adjust the repository URL to convert the "gitlab" scheme to "https"
-     * @param repository Repository as source of URL
-     * @return The new corrected URL as a string.
-     */
-    private String correctUrl(Repository repository) {
-        return repository.getUrl().replace(GITLAB_SCHEME, REPOSITORY_SCHEME);
     }
 
     /**

--- a/src/main/resources/leiningen/wagons.clj
+++ b/src/main/resources/leiningen/wagons.clj
@@ -1,1 +1,2 @@
-{"gitlab" #(com.nicheware.maven.LeinGitlabWagon.)}
+{"gitlab" #(com.nicheware.maven.LeinGitlabWagon.)
+ "gitlab-insecure" #(com.nicheware.maven.LeinGitlabWagon.)}


### PR DESCRIPTION
issue #4 

For some very rare cases, the self-host gitlab instance is not equipped with a domain name. So, there is no way to access via `https`. 
Consider adding non-secure support, such as:
 
for `gitlab://gitlab.com/blahblah`  converts to `https://gitlab.com/blahblah`
for `gitlab-insecure://gitlab.com/blahblah` converts to `http://gitlab.com/blahblah`
